### PR TITLE
Add WebSocket authentication support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,8 @@
 /*.db*
+/target/
+/.claude/
+/debug_auth
+/chainpulse.local.toml
+*.local.toml
+.env
+.env.local

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,8 +10,12 @@ repository   = "https://github.com/informalsystems/chainpulse"
 lto = 'thin'
 
 [dependencies]
+async-trait = "0.1.88"
+async-tungstenite = { version = "0.29.1", features = ["tokio-runtime", "tokio-rustls-webpki-roots"] }
 axum               = "0.6"
+base64 = "0.22.1"
 clap               = { version = "4.4", features = ["derive"] }
+rustls = { version = "0.23", features = ["ring"] }
 ctrlc              = { version = "3.4", features = ["termination"] }
 futures            = "0.3"
 ibc-proto          = { version = "0.34.1", default-features = false }
@@ -27,7 +31,8 @@ tendermint-proto   = "0.32"
 tendermint-rpc     = { version = "0.32", features = ["websocket-client"] }
 thiserror          = "1"
 time               = "0.3"
-tokio              = { version = "1", features = ["full"] }
+tokio              = { version = "1", features = ["full", "sync"] }
 toml               = "0.8.0"
 tracing            = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter", "registry"] }
+url                = "2.4"

--- a/README.md
+++ b/README.md
@@ -55,6 +55,25 @@ port    = 3000
 
 Note: The `comet_version` field is optional and defaults to "0.34".
 
+### Authentication
+
+ChainPulse supports authentication for private RPC endpoints. You can provide username and password in the configuration:
+
+```toml
+[chains.private-chain]
+url = "wss://private-rpc.example.com/websocket"
+comet_version = "0.34"
+username = "your-username"
+password = "your-password"
+```
+
+ChainPulse implements a custom WebSocket client that supports various authentication methods:
+- **Basic Authentication**: Automatically sends credentials as Basic Auth headers during WebSocket handshake
+- **Bearer Token**: Support for Bearer token authentication (future)
+- **API Key**: Support for custom API key headers (future)
+
+This custom implementation bypasses the limitations of the standard tendermint-rpc library, which doesn't support authentication headers.
+
 ## Usage
 
 ```

--- a/chainpulse.example.toml
+++ b/chainpulse.example.toml
@@ -1,3 +1,6 @@
+# Example configuration for ChainPulse
+# Copy this file to chainpulse.toml and modify as needed
+
 # Chains to monitor, with their chain identifier, Comet/Tendermint version, and the URL of their WebSocket endpoint.
 [chains.cosmoshub-4]
 url = "wss://neutron-rpc.lavenderfive.com/websocket"
@@ -33,3 +36,9 @@ port = 3000
 # where either the source or destination chain is part of the
 # list of chains to monitor.
 stuck_packets = true
+
+# Whether or not to populate metrics on startup
+# by querying the database for the chains which are to be monitored.
+# Populating the metrics on start can take a significant amount of time
+# depending on the size of the database.
+populate_on_start = false

--- a/src/config.rs
+++ b/src/config.rs
@@ -40,6 +40,12 @@ pub struct Endpoint {
         with = "crate::config::comet_version"
     )]
     pub comet_version: CometVersion,
+    
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub username: Option<String>,
+    
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub password: Option<String>,
 }
 
 #[derive(Clone, Debug, Deserialize, Serialize)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,6 +4,7 @@ pub mod db;
 pub mod metrics;
 pub mod msg;
 pub mod populate;
+pub mod simple_auth_client;
 pub mod status;
 
 use std::path::PathBuf;
@@ -85,6 +86,8 @@ async fn collect(chain_id: chain::Id, endpoint: Endpoint, pool: SqlitePool, metr
         chain_id,
         endpoint.comet_version,
         endpoint.url,
+        endpoint.username,
+        endpoint.password,
         pool,
         metrics,
     )

--- a/src/simple_auth_client.rs
+++ b/src/simple_auth_client.rs
@@ -1,0 +1,118 @@
+use async_tungstenite::{
+    tokio::connect_async_with_config,
+    tungstenite::{
+        client::IntoClientRequest,
+        http::HeaderValue,
+        Message,
+    },
+};
+use futures::{SinkExt, StreamExt};
+use std::sync::Arc;
+use tendermint::Block;
+use tokio::sync::Mutex;
+use tracing::{debug, error, info};
+
+#[derive(Debug, Clone)]
+pub enum AuthMethod {
+    None,
+    Basic { username: String, password: String },
+    Bearer { token: String },
+    ApiKey { header_name: String, key: String },
+}
+
+/// Simple authenticated WebSocket client for block subscriptions
+pub struct SimpleAuthClient {
+    url: String,
+    auth_method: AuthMethod,
+}
+
+impl SimpleAuthClient {
+    pub fn new(url: String, auth_method: AuthMethod) -> Self {
+        Self { url, auth_method }
+    }
+    
+    /// Subscribe to blocks and return a stream
+    pub async fn subscribe_blocks(
+        self,
+    ) -> Result<BlockStream, Box<dyn std::error::Error + Send + Sync>> {
+        // Initialize rustls crypto provider if not already initialized
+        let _ = rustls::crypto::ring::default_provider().install_default();
+        
+        // Build request with authentication
+        let mut request = self.url.into_client_request()?;
+        
+        match &self.auth_method {
+            AuthMethod::None => {}
+            AuthMethod::Basic { username, password } => {
+                let credentials = base64::Engine::encode(
+                    &base64::engine::general_purpose::STANDARD,
+                    format!("{}:{}", username, password)
+                );
+                request.headers_mut().insert(
+                    "Authorization",
+                    HeaderValue::from_str(&format!("Basic {}", credentials))?,
+                );
+            }
+            _ => return Err("Unsupported auth method".into()),
+        }
+        
+        info!("Connecting to WebSocket with authentication...");
+        let (ws_stream, _) = connect_async_with_config(request, None).await?;
+        info!("WebSocket connection established");
+        
+        let (mut write, mut read) = ws_stream.split();
+        
+        // Send subscription request
+        let subscribe_msg = r#"{"jsonrpc":"2.0","method":"subscribe","params":{"query":"tm.event = 'NewBlock'"},"id":1}"#;
+        write.send(Message::Text(subscribe_msg.to_string().into())).await?;
+        
+        // Read subscription response
+        if let Some(Ok(Message::Text(response))) = read.next().await {
+            debug!("Subscription response: {}", response);
+        }
+        
+        Ok(BlockStream {
+            read: Arc::new(Mutex::new(read)),
+        })
+    }
+}
+
+/// Stream of blocks from WebSocket
+pub struct BlockStream {
+    read: Arc<Mutex<futures::stream::SplitStream<async_tungstenite::WebSocketStream<async_tungstenite::tokio::ConnectStream>>>>,
+}
+
+impl BlockStream {
+    /// Get next block
+    pub async fn next(&mut self) -> Option<Block> {
+        let mut read = self.read.lock().await;
+        
+        while let Some(result) = read.next().await {
+            match result {
+                Ok(Message::Text(text)) => {
+                    // Try to parse as event
+                    if let Ok(json) = serde_json::from_str::<serde_json::Value>(&text) {
+                        // Check if it's a block event
+                        if let Some(block_json) = json["result"]["data"]["value"]["block"].as_object() {
+                            // Parse block
+                            if let Ok(block) = serde_json::from_value::<Block>(serde_json::Value::Object(block_json.clone())) {
+                                return Some(block);
+                            }
+                        }
+                    }
+                }
+                Ok(Message::Close(_)) => {
+                    info!("WebSocket closed");
+                    return None;
+                }
+                Err(e) => {
+                    error!("WebSocket error: {}", e);
+                    return None;
+                }
+                _ => {} // Ignore other message types
+            }
+        }
+        
+        None
+    }
+}


### PR DESCRIPTION
- Implement custom WebSocket client with Basic Auth header support
- Add username/password fields to chain configuration
- Create SimpleAuthClient that bypasses tendermint-rpc limitations
- Add comprehensive .gitignore for sensitive files
- Create chainpulse.example.toml as template
- Update README with authentication documentation

This allows connection to auth-gated endpoints, which is not supported by default due to library choices.